### PR TITLE
Make base url configurable

### DIFF
--- a/__tests__/hooks/useEvmTokenBalances.test.tsx
+++ b/__tests__/hooks/useEvmTokenBalances.test.tsx
@@ -78,7 +78,8 @@ describe("useTokenBalances", () => {
     expect(mockFetchEvmBalances).toHaveBeenCalledWith(
       walletAddress,
       {},
-      process.env.DUNE_API_KEY
+      process.env.DUNE_API_KEY,
+      "https://api.dune.com"
     );
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
@@ -106,7 +107,8 @@ describe("useTokenBalances", () => {
     expect(mockFetchEvmBalances).toHaveBeenCalledWith(
       walletAddress,
       {},
-      process.env.DUNE_API_KEY
+      process.env.DUNE_API_KEY,
+      "https://api.dune.com"
     );
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toEqual(mockError);

--- a/__tests__/hooks/useEvmTransactions.test.tsx
+++ b/__tests__/hooks/useEvmTransactions.test.tsx
@@ -91,7 +91,8 @@ describe("useTransactions", () => {
     expect(mockFetchEvmTransactions).toHaveBeenCalledWith(
       walletAddress,
       { offset: undefined },
-      process.env.DUNE_API_KEY
+      process.env.DUNE_API_KEY,
+      "https://api.dune.com"
     );
     expect(result.current.data).toEqual(mockResponse);
     expect(result.current.nextOffset).toBe("offset1");
@@ -119,7 +120,8 @@ describe("useTransactions", () => {
     expect(mockFetchEvmTransactions).toHaveBeenCalledWith(
       walletAddress,
       { offset: undefined },
-      process.env.DUNE_API_KEY
+      process.env.DUNE_API_KEY,
+      "https://api.dune.com"
     );
     expect(result.current.error).toEqual(mockError);
     expect(result.current.data).toBeNull();

--- a/__tests__/hooks/useSvmTokenBalances.test.tsx
+++ b/__tests__/hooks/useSvmTokenBalances.test.tsx
@@ -65,7 +65,8 @@ describe("useTokenBalances", () => {
     expect(mockFetchSvmBalances).toHaveBeenCalledWith(
       walletAddress,
       {},
-      process.env.DUNE_API_KEY
+      process.env.DUNE_API_KEY,
+      "https://api.dune.com"
     );
     expect(svmResult.current.isLoading).toBe(false);
     expect(svmResult.current.error).toBeNull();
@@ -97,7 +98,8 @@ describe("useTokenBalances", () => {
     expect(mockFetchSvmBalances).toHaveBeenCalledWith(
       walletAddress,
       {},
-      process.env.DUNE_API_KEY
+      process.env.DUNE_API_KEY,
+      "https://api.dune.com"
     );
     expect(svmResult.current.isLoading).toBe(false);
     expect(svmResult.current.error).toEqual(mockError);

--- a/__tests__/hooks/useSvmTransactions.test.tsx
+++ b/__tests__/hooks/useSvmTransactions.test.tsx
@@ -78,7 +78,8 @@ describe("useTransactions", () => {
     expect(mockFetchSvmTransactions).toHaveBeenCalledWith(
       walletAddress,
       { offset: undefined },
-      process.env.DUNE_API_KEY
+      process.env.DUNE_API_KEY,
+      "https://api.dune.com"
     );
     expect(svmResult.current.data).toEqual(mockResponse);
     expect(svmResult.current.nextOffset).toBe("offset1");
@@ -109,7 +110,8 @@ describe("useTransactions", () => {
     expect(mockFetchSvmTransactions).toHaveBeenCalledWith(
       walletAddress,
       { offset: undefined },
-      process.env.DUNE_API_KEY
+      process.env.DUNE_API_KEY,
+      "https://api.dune.com"
     );
     expect(svmResult.current.error).toEqual(mockError);
     expect(svmResult.current.data).toBeNull();

--- a/src/evm/duneApi.ts
+++ b/src/evm/duneApi.ts
@@ -5,9 +5,8 @@ import {
   TransactionsParams,
 } from "./types";
 
-const BALANCE_API_BASE_URL = "https://api.dune.com/api/echo/v1/balances/evm";
-const TRANSACTIONS_API_BASE_URL =
-  "https://api.dune.com/api/echo/v1/transactions/evm";
+const BALANCES_PREFIX = "api/echo/v1/balances/evm";
+const TRANSACTIONS_PREFIX = "api/echo/v1/transactions/evm";
 
 const getBalanceQueryParams = (
   params: TokenBalancesParams
@@ -40,10 +39,11 @@ const getTransactionsQueryParams = (
 export async function fetchEvmBalances(
   walletAddress: string,
   params: TokenBalancesParams,
-  duneApiKey: string
+  duneApiKey: string,
+  baseUrl: string
 ): Promise<BalanceData> {
   const queryParams = getBalanceQueryParams(params);
-  const apiUrl = `${BALANCE_API_BASE_URL}/${walletAddress}?${queryParams.toString()}`;
+  const apiUrl = `${baseUrl}/${BALANCES_PREFIX}/${walletAddress}?${queryParams.toString()}`;
 
   const response = await fetch(apiUrl, {
     method: "GET",
@@ -65,10 +65,11 @@ export const fetchBalances = fetchEvmBalances;
 export async function fetchEvmTransactions(
   walletAddress: string,
   params: TransactionsParams,
-  duneApiKey: string
+  duneApiKey: string,
+  baseUrl: string
 ): Promise<TransactionData> {
   const queryParams = getTransactionsQueryParams(params);
-  const apiUrl = `${TRANSACTIONS_API_BASE_URL}/${walletAddress}?${queryParams.toString()}`;
+  const apiUrl = `${baseUrl}/${TRANSACTIONS_PREFIX}/${walletAddress}?${queryParams.toString()}`;
 
   const response = await fetch(apiUrl, {
     method: "GET",

--- a/src/evm/useEvmTokenBalances.ts
+++ b/src/evm/useEvmTokenBalances.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { TokenBalancesParams, BalanceData, FetchError } from "./types";
 import { fetchEvmBalances } from "./duneApi";
 import { useDeepMemo } from "../useDeepMemo";
-import { useGetApiKey } from "../provider";
+import { useGetApiKey, useGetBaseUrl } from "../provider";
 import { isAddress } from "viem";
 
 export const useEvmTokenBalances = (
@@ -28,6 +28,7 @@ export const useEvmTokenBalances = (
 
   const memoizedParams = useDeepMemo(() => params, params);
   const apiKey = useGetApiKey();
+  const baseUrl = useGetBaseUrl();
 
   // Function to fetch data for a specific page
   const fetchDataAsync = async (offset: string | null) => {
@@ -45,7 +46,8 @@ export const useEvmTokenBalances = (
       const result = await fetchEvmBalances(
         walletAddress,
         updatedParams,
-        apiKey
+        apiKey,
+        baseUrl
       );
 
       setState((prevState) => ({

--- a/src/evm/useEvmTransactions.ts
+++ b/src/evm/useEvmTransactions.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { TransactionsParams, TransactionData, FetchError } from "./types";
 import { fetchEvmTransactions } from "./duneApi";
 import { useDeepMemo } from "../useDeepMemo";
-import { useGetApiKey } from "../provider";
+import { useGetApiKey, useGetBaseUrl } from "../provider";
 import { isAddress } from "viem";
 
 export const useEvmTransactions = (
@@ -28,6 +28,7 @@ export const useEvmTransactions = (
 
   const memoizedParams = useDeepMemo(() => params, [params]);
   const apiKey = useGetApiKey();
+  const baseUrl = useGetBaseUrl();
 
   // Function to fetch data for a specific page
   const fetchDataAsync = async (offset: string | null) => {
@@ -45,7 +46,8 @@ export const useEvmTransactions = (
       const result = await fetchEvmTransactions(
         walletAddress,
         updatedParams,
-        apiKey
+        apiKey,
+        baseUrl
       );
 
       setState((prevState) => ({

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -2,9 +2,13 @@ import React, { createContext, useContext } from "react";
 
 interface DuneContextType {
   duneApiKey: string;
+  baseUrl?: string;
 }
 
-const DuneContext = createContext<DuneContextType>({ duneApiKey: "" });
+const DuneContext = createContext<DuneContextType>({
+  duneApiKey: "",
+  baseUrl: "",
+});
 
 export const useDuneContext = () => {
   const context = useContext(DuneContext);
@@ -19,14 +23,27 @@ export const useGetApiKey = () => {
   return context.duneApiKey;
 };
 
+export const useGetBaseUrl = () => {
+  const context = useDuneContext();
+  if (!context.baseUrl) {
+    return "https://api.dune.com";
+  }
+  return context.baseUrl;
+};
+
 interface DuneProviderProps {
   duneApiKey: string;
+  baseUrl?: string;
   children: React.ReactNode;
 }
 
-export const DuneProvider = ({ duneApiKey, children }: DuneProviderProps) => {
+export const DuneProvider = ({
+  duneApiKey,
+  baseUrl,
+  children,
+}: DuneProviderProps) => {
   return (
-    <DuneContext.Provider value={{ duneApiKey }}>
+    <DuneContext.Provider value={{ duneApiKey, baseUrl }}>
       {children}
     </DuneContext.Provider>
   );

--- a/src/svm/duneApi.ts
+++ b/src/svm/duneApi.ts
@@ -5,9 +5,8 @@ import {
   TransactionsParams,
 } from "./types";
 
-const BALANCE_API_BASE_URL = "https://api.dune.com/api/echo/beta/balances/svm/";
-const TRANSACTIONS_API_BASE_URL =
-  "https://api.dune.com/api/echo/beta/transactions/svm/";
+const BALANCES_PREFIX = "api/echo/beta/balances/svm";
+const TRANSACTIONS_PREFIX = "api/echo/beta/transactions/svm";
 
 const getBalanceQueryParams = (
   params: TokenBalancesParams
@@ -31,10 +30,11 @@ const getTransactionsQueryParams = (
 export async function fetchSvmBalances(
   walletAddress: string,
   params: TokenBalancesParams,
-  duneApiKey: string
+  duneApiKey: string,
+  baseUrl: string
 ): Promise<BalanceData> {
   const queryParams = getBalanceQueryParams(params);
-  const apiUrl = `${BALANCE_API_BASE_URL}/${walletAddress}?${queryParams.toString()}`;
+  const apiUrl = `${baseUrl}/${BALANCES_PREFIX}/${walletAddress}?${queryParams.toString()}`;
 
   const response = await fetch(apiUrl, {
     method: "GET",
@@ -53,10 +53,11 @@ export async function fetchSvmBalances(
 export async function fetchSvmTransactions(
   walletAddress: string,
   params: TransactionsParams,
-  duneApiKey: string
+  duneApiKey: string,
+  baseUrl: string
 ): Promise<TransactionData> {
   const queryParams = getTransactionsQueryParams(params);
-  const apiUrl = `${TRANSACTIONS_API_BASE_URL}/${walletAddress}?${queryParams.toString()}`;
+  const apiUrl = `${baseUrl}/${TRANSACTIONS_PREFIX}/${walletAddress}?${queryParams.toString()}`;
 
   const response = await fetch(apiUrl, {
     method: "GET",

--- a/src/svm/useSvmTokenBalances.ts
+++ b/src/svm/useSvmTokenBalances.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { TokenBalancesParams, BalanceData, FetchError } from "./types";
 import { fetchSvmBalances } from "./duneApi";
 import { useDeepMemo } from "../useDeepMemo";
-import { useGetApiKey } from "../provider";
+import { useGetApiKey, useGetBaseUrl } from "../provider";
 
 export const useSvmTokenBalances = (
   walletAddress: string,
@@ -27,6 +27,7 @@ export const useSvmTokenBalances = (
 
   const memoizedParams = useDeepMemo(() => params, params);
   const apiKey = useGetApiKey();
+  const baseUrl = useGetBaseUrl();
 
   // Function to fetch data for a specific page
   const fetchDataAsync = async (offset: string | null) => {
@@ -44,7 +45,8 @@ export const useSvmTokenBalances = (
       const result = await fetchSvmBalances(
         walletAddress,
         updatedParams,
-        apiKey
+        apiKey,
+        baseUrl
       );
 
       setState((prevState) => ({

--- a/src/svm/useSvmTransactions.ts
+++ b/src/svm/useSvmTransactions.ts
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { TransactionsParams, TransactionData, FetchError } from "./types";
 import { fetchSvmTransactions } from "./duneApi";
 import { useDeepMemo } from "../useDeepMemo";
-import { useGetApiKey } from "../provider";
+import { useGetApiKey, useGetBaseUrl } from "../provider";
 
 export const useSvmTransactions = (
   walletAddress: string,
@@ -27,6 +27,7 @@ export const useSvmTransactions = (
 
   const memoizedParams = useDeepMemo(() => params, [params]);
   const apiKey = useGetApiKey();
+  const baseUrl = useGetBaseUrl();
 
   // Function to fetch data for a specific page
   const fetchDataAsync = async (offset: string | null) => {
@@ -44,7 +45,8 @@ export const useSvmTransactions = (
       const result = await fetchSvmTransactions(
         walletAddress,
         updatedParams,
-        apiKey
+        apiKey,
+        baseUrl
       );
 
       setState((prevState) => ({


### PR DESCRIPTION
The default is still `https://api.dune.com/api/echo` but users now have the option to override it by passing `baseUrl` into `DuneProvider`