### PR TITLE
chore: add support for React 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
-        "react-dom": "^18.3.1",
         "tslib": "^2.7.0",
         "viem": "^2.22.9"
       },
@@ -26,17 +25,20 @@
         "@testing-library/react": "^16.1.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.6",
-        "@types/react": "18.2.25",
+        "@types/react": "^18.3.20",
+        "@types/react-dom": "^18.3.6",
         "dotenv": "^16.4.7",
         "jsdom": "^26.0.0",
         "prettier": "^3.4.2",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
         "rollup": "^3.0.0",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "typescript": "^5.0.0",
         "vitest": "^2.1.8"
       },
       "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3077,26 +3079,30 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.25",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.25.tgz",
-      "integrity": "sha512-24xqse6+VByVLIr+xWaQ9muX1B4bXJKXBbjszbld/UEDslGLY53+ZucF44HCmLbMPejTzGG9XgR+3m2/Wqu1kw==",
+      "version": "18.3.20",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
+      "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.6.tgz",
+      "integrity": "sha512-nf22//wEbKXusP6E9pfOCDwFdHAX4u172eaJI4YkDRQEZiorm6KfYnSC2SWLDMVWUOWPERmJnN0ujeAfTBLvrw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
-      "dev": true
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-YIoDCTH3Af6XM5VuwGG/QL/CJqga1Zm3NkU3HZ4ZHK2fRMPYP1VczsTUqtsf43PH/iJNVlPHAo2oWX7BSdB2Hw==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -4425,7 +4431,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/jsdom": {
       "version": "26.0.0",
@@ -4507,6 +4514,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -4812,7 +4820,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4824,6 +4832,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4989,6 +4998,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
   "prettier": {
     "trailingComma": "es5"
   },
+  "packageManager": "npm@10.9.0",
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
@@ -37,10 +38,13 @@
     "@testing-library/react": "^16.1.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.6",
-    "@types/react": "18.2.25",
+    "@types/react": "^18.3.20",
+    "@types/react-dom": "^18.3.6",
     "dotenv": "^16.4.7",
     "jsdom": "^26.0.0",
     "prettier": "^3.4.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "rollup": "^3.0.0",
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "typescript": "^5.0.0",
@@ -58,7 +62,6 @@
     "url": "git+https://github.com/duneanalytics/hooks.git"
   },
   "dependencies": {
-    "react-dom": "^18.3.1",
     "tslib": "^2.7.0",
     "viem": "^2.22.9"
   },


### PR DESCRIPTION
## Changes
- add react v19 to `peerDependencies`
- define `packageManager` field
- install missing `react` and `@types/react-dom` dependencies
- move `react-dom` from `dependencies` to `devDependencies`

## Motivation

https://github.com/duneanalytics/dune.com is currently blocked from upgrading to React 19.

```
├─┬ @duneanalytics/hooks 1.1.2
│ ✕ unmet peer react@"^17.0.0 || ^18.0.0": found 19.1.0
│ └─┬ react-dom 18.3.1
│   └── ✕ unmet peer react@^18.3.1: found 19.1.0
```

I verified against the dune monorepo with temporarily upgraded React 19 that this lib still gets consumed properly.