### PR TITLE
fix: invalid types path defined in package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     ".": {
       "import": "./dist/index.esm.js",
       "require": "./dist/index.cjs.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/types/index.d.ts"
     }
   }
 }


### PR DESCRIPTION
## Changes
- update incorrect exports types path from `./dist/index.d.ts` to `./dist/types/index.d.ts`

## Motivation
https://github.com/duneanalytics/dune.com/pull/4830 is currently failing TS checks because `@duneanalytics/hooks` points to an invalid types folder.